### PR TITLE
Use more self-documenting variable names

### DIFF
--- a/artificial_neural_network.py
+++ b/artificial_neural_network.py
@@ -1,5 +1,5 @@
-#Importing Python libraries
-import tensorflow as t
+# Importing Python libraries
+import tensorflow as tf
 import pandas as pd
 import numpy as np
 from sklearn.preprocessing import LabelEncoder
@@ -10,49 +10,49 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.metrics import confusion_matrix, accuracy_score
 from sklearn.linear_model import LogisticRegression
 import pickle
-#Data Preprocessing
-d = pd.read_csv('Churn_Modelling.csv')
-x = d.iloc[:, 3:-1].values
-y = d.iloc[:,-1].values
+# Data Preprocessing
+dataset = pd.read_csv('Churn_Modelling.csv')
+x = dataset.iloc[:, 3:-1].values
+y = dataset.iloc[:,-1].values
 print(x)
 print(y)
-#Labelling Encoding 
-r = LabelEncoder()
-x[:,2]=r.fit_transform(x[:,2])
+# Labelling Encoding 
+label_encoder = LabelEncoder()
+x[:,2]=label_encoder.fit_transform(x[:,2])
 print(x)
-#Geography Column
-c = ColumnTransformer(transformers = [('encoder', OneHotEncoder(), [1])], remainder='passthrough')
-x = np.array(c.fit_transform(x))
+# Geography Column
+column_transformer = ColumnTransformer(transformers = [('encoder', OneHotEncoder(), [1])], remainder='passthrough')
+x = np.array(column_transformer.fit_transform(x))
 print(x)
-#Spliting data set and test set
+# Spliting data set and test set
 x_train,x_test,y_train,y_test = train_test_split(x,y,test_size=0.2,random_state=0)
-#Feature Scaling
-p = StandardScaler()
-x_train=p.fit_transform(x_train)
-x_test-p.transform(x_test)
-#Including ANN
-ann = t.keras.models.Sequential()
-ann.add(t.keras.layers.Dense(units = 6,activation = 'swish'))
-ann.add(t.keras.layers.Dense(units = 6,activation='swish'))
-ann.add(t.keras.layers.Dense(units = 1,activation='tanh'))
-#Training ANN
+# Feature Scaling
+standard_scaler = StandardScaler()
+x_train=standard_scaler.fit_transform(x_train)
+x_test-standard_scaler.transform(x_test)
+# Including ANN
+ann = tf.keras.models.Sequential()
+ann.add(tf.keras.layers.Dense(units = 6,activation = 'swish'))
+ann.add(tf.keras.layers.Dense(units = 6,activation='swish'))
+ann.add(tf.keras.layers.Dense(units = 1,activation='tanh'))
+# Training ANN
 ann.compile(optimizer = 'adam' , loss = 'binary_crossentropy', metrics =['accuracy'])
 ann.fit(x_train,y_train,batch_size = 32, epochs = 20)
 =======
-ann.add(t.keras.layers.Dense(units = 6,activation = 'relu'))
-ann.add(t.keras.layers.Dense(units = 6,activation='relu'))
-ann.add(t.keras.layers.Dense(units = 1,activation='sigmoid'))
-#Training ANN
+ann.add(tf.keras.layers.Dense(units = 6,activation = 'relu'))
+ann.add(tf.keras.layers.Dense(units = 6,activation='relu'))
+ann.add(tf.keras.layers.Dense(units = 1,activation='sigmoid'))
+# Training ANN
 #ann.compile(optimizer = 'adam' , loss = 'binary_crossentropy', metrics =['accuracy'])
 #ann.fit(x_train,y_train,batch_size = 32, epochs = 20)
-#Predicting and evaluating models
-print(ann.predict(p.transform([[1,0,0,600,1,40,3,60000,2,1,1,50000]])))
-#Predicting Test Results
+# Predicting and evaluating models
+print(ann.predict(standard_scaler.transform([[1,0,0,600,1,40,3,60000,2,1,1,50000]])))
+# Predicting Test Results
 classifier = LogisticRegression(random_state = 0)
 classifier.fit(x_train, y_train)
 y_pred = classifier.predict(x_test)
-with open('classifier.dat','wb') as f:
-    pickle.dump(classifier,f)
+with open('classifier.dat','wb') as out_file:
+    pickle.dump(classifier,out_file)
     print('Saved Successfully')
 ann.save('./model.h5')
 print(np.concatenate((y_pred.reshape(len(y_pred),1), y_test.reshape(len(y_test),1)),1))


### PR DESCRIPTION
Single letter variable names make code less readable and harder to maintain.  It also makes the code look lik it was written in the 1970s.